### PR TITLE
Remove `pathlib` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ repository = "https://github.com/BrainLesion/auxiliary"
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-pathlib = ">=1.0"
 nibabel = ">=3.0"
 numpy = ">=1.24"
 tifffile = ">=2023.8.25"


### PR DESCRIPTION
It has been standard in python > 3.4 [[ref](https://docs.python.org/3/library/pathlib.html#module-pathlib)].