### PR TITLE
Any reason for the `0.7.3` requirement for loguru?

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ tifffile = ">=2023.8.25"
 path = ">=17.0.0"
 pillow = ">=10.0.0"
 simpleitk = ">=2.2.1"
-loguru = "^0.7.3"
+loguru = "^0.7.2"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=6.2"


### PR DESCRIPTION
Would be great if we can bring this down to `0.7.2` (ref: https://github.com/conda-forge/loguru-feedstock/pull/40)